### PR TITLE
Add .scala-steward.conf in series/1.x

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,4 @@
+updates.pin = [
+  # zio 1.0 should stay on zio 1.0
+  { groupId = "dev.zio", version = "1.0."}
+]


### PR DESCRIPTION
Applying this PR will add a .scala-steward.conf file. This should prevent scala-steward from creating PR's to update zio 1.0 to 2.x.