### PR TITLE
Fix SubscriberImpl and wait for cluster to be up and use an ephemeral port

### DIFF
--- a/zio-pekko-cluster/src/main/scala/zio/pekko/cluster/pubsub/impl/SubscriberImpl.scala
+++ b/zio-pekko-cluster/src/main/scala/zio/pekko/cluster/pubsub/impl/SubscriberImpl.scala
@@ -4,7 +4,7 @@ import org.apache.pekko.actor.{Actor, ActorRef, ActorSystem, PoisonPill, Props}
 import org.apache.pekko.cluster.pubsub.DistributedPubSubMediator.{Subscribe, SubscribeAck}
 import SubscriberImpl.SubscriberActor
 import zio.pekko.cluster.pubsub.{MessageEnvelope, Subscriber}
-import zio.{Exit, Promise, Queue, Runtime, Task, Unsafe, ZIO}
+import zio.{Exit, Fiber, Promise, Queue, Runtime, Task, Unsafe, ZIO}
 
 private[pubsub] trait SubscriberImpl[A] extends Subscriber[A] {
   val getActorSystem: ActorSystem
@@ -30,6 +30,10 @@ object SubscriberImpl {
       queue: Queue[A],
       subscribed: Promise[Nothing, Unit]
   ) extends Actor {
+    private var pending: Fiber.Runtime[Nothing, Unit] =
+      Unsafe.unsafe { implicit u =>
+        rts.unsafe.fork(ZIO.unit)
+      }
 
     mediator ! Subscribe(topic, group, self)
 
@@ -41,11 +45,13 @@ object SubscriberImpl {
         ()
       case MessageEnvelope(msg) =>
         Unsafe.unsafe { implicit u =>
-          val fiber = rts.unsafe.fork(queue.offer(msg.asInstanceOf[A]))
-          fiber.unsafe.addObserver {
+          val previous = pending
+          val next     = rts.unsafe.fork(previous.join *> queue.offer(msg.asInstanceOf[A]).unit)
+          next.unsafe.addObserver {
             case Exit.Success(_) => ()
             case Exit.Failure(c) => if (c.isInterrupted) self ! PoisonPill // stop listening if the queue was shut down
           }
+          pending = next
         }
         ()
     }

--- a/zio-pekko-cluster/src/test/scala/zio/pekko/cluster/pubsub/PubSubSpec.scala
+++ b/zio-pekko-cluster/src/test/scala/zio/pekko/cluster/pubsub/PubSubSpec.scala
@@ -2,11 +2,12 @@ package zio.pekko.cluster.pubsub
 
 import org.apache.pekko.actor.ActorSystem
 import com.typesafe.config.{Config, ConfigFactory}
+import org.apache.pekko.cluster.MemberStatus
 import zio.test.Assertion._
 import zio.test._
 import zio.test.TestEnvironment
 import zio.test.ZIOSpecDefault
-import zio.{ExecutionStrategy, ZIO, ZLayer}
+import zio.{ExecutionStrategy, ZIO, ZLayer, durationInt}
 
 object PubSubSpec extends ZIOSpecDefault {
 
@@ -19,20 +20,34 @@ object PubSubSpec extends ZIOSpecDefault {
                                                     |    enabled-transports = ["pekko.remote.artery.canonical"]
                                                     |    artery.canonical {
                                                     |      hostname = "127.0.0.1"
-                                                    |      port = 17357
+                                                    |      port = 0
                                                     |    }
                                                     |  }
                                                     |  cluster {
-                                                    |    seed-nodes = ["pekko://Test@127.0.0.1:17357"]
+                                                    |    seed-nodes = []
+                                                    |    jmx.multi-mbeans-in-same-jvm = on
                                                     |    downing-provider-class = "org.apache.pekko.cluster.sbr.SplitBrainResolverProvider"
                                                     |  }
                                                     |}
            """.stripMargin)
 
+  private def awaitMemberUp(cluster: org.apache.pekko.cluster.Cluster): ZIO[Any, Throwable, Unit] =
+    ZIO.attempt(cluster.selfMember.status).flatMap {
+      case MemberStatus.Up => ZIO.unit
+      case _               => ZIO.sleep(100.millis) *> awaitMemberUp(cluster)
+    }
+
   val actorSystem: ZLayer[Any, Throwable, ActorSystem] =
     ZLayer
       .scoped(
-        ZIO.acquireRelease(ZIO.attempt(ActorSystem("Test", config)))(sys => ZIO.fromFuture(_ => sys.terminate()).either)
+        ZIO.acquireRelease(
+          for {
+            sys     <- ZIO.attempt(ActorSystem("Test", config))
+            cluster <- ZIO.attempt(org.apache.pekko.cluster.Cluster(sys))
+            _       <- ZIO.attempt(cluster.join(cluster.selfAddress))
+            _       <- awaitMemberUp(cluster)
+          } yield sys
+        )(sys => ZIO.fromFuture(_ => sys.terminate()).either)
       )
 
   val topic = "topic"
@@ -102,5 +117,6 @@ object PubSubSpec extends ZIOSpecDefault {
           } yield List(item1, item2)
         )(equalTo(List(msg, msg))).provideLayer(actorSystem)
       }
-    ) @@ TestAspect.executionStrategy(ExecutionStrategy.Sequential)
+    ) @@ TestAspect.executionStrategy(ExecutionStrategy.Sequential) @@ TestAspect.timeout(30.seconds) @@
+      TestAspect.withLiveClock
 }


### PR DESCRIPTION
Applying this PR will wait for the cluster to be up before calls are made and no longer use a fixed port in the tests. This should fix the flakiness of this spec. Also use a single chained fiber per subscriber actor in SubscriberImpl.